### PR TITLE
fix compiling failures on PyBind11 and gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@
 set(CMAKE_CXX_STANDARD 20)
 project ("OrthoMeshTools" C CXX)
 
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_FLAGS "-fpermissive -fPIC -fopenmp")
+
 add_compile_definitions(NOMINMAX)
 
 find_package(Eigen3 REQUIRED)
@@ -11,47 +15,51 @@ find_package(assimp REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(pybind11 CONFIG)
 find_package(Ceres)
-find_package(argparse)
 include(CGAL_Eigen3_support)
 include(CGAL_Ceres_support)
+
+include_directories("./")
 
 add_library(Ortho "Polyhedron.cpp" "Polyhedron.h" "Ortho.h")
 target_link_libraries(Ortho PUBLIC CGAL::CGAL CGAL::Eigen3_support nlohmann_json::nlohmann_json OpenMP::OpenMP_CXX assimp::assimp)
 
-add_executable(MeshFix "MeshFix/MeshFix.cpp" "MeshFix/MeshFix.h" "MeshFix/MeshFixApp.cpp")
-target_compile_definitions(MeshFix PRIVATE _USE_MATH_DEFINES)
-target_link_libraries(MeshFix PUBLIC Ortho argparse::argparse)
-
-add_executable(SegClean "SegClean/SegClean.cpp" "SegClean/SegClean.h")
-target_link_libraries(SegClean PUBLIC Ortho argparse::argparse)
-
-add_executable(ReSegment "ReSegment/ReSegment.cpp" "ReSegment/ReSegment.h")
-target_link_libraries(ReSegment PUBLIC Ortho argparse::argparse)
-
-add_executable(HoleMerge "HoleMerge/HoleMerge.cpp" "HoleMerge/HoleMerge.h")
-target_link_libraries(HoleMerge PUBLIC Ortho argparse::argparse)
-
-add_executable(GumTrimLine "GumTrimLine/GumTrimLine.cpp"  "GumTrimLine/GumTrimLineApp.cpp" "GumTrimLine/GumTrimLine.h" "MeshFix/MeshFix.cpp")
-target_link_libraries(GumTrimLine PUBLIC Ortho argparse::argparse)
-
-add_executable(ColorMeshByLabel "ColorMeshByLabel/ColorMeshByLabel.cpp" "ColorMeshByLabel/ColorMeshByLabel.h")
-target_link_libraries(ColorMeshByLabel PUBLIC Ortho argparse::argparse)
-
-add_executable(OrthoScanDeform "OrthoScanDeform/OrthoScanDeformApp.cpp" "OrthoScanDeform/OrthoScanDeform.h" "MeshFix/MeshFix.cpp")
-target_link_libraries(OrthoScanDeform PUBLIC Ortho argparse::argparse)
-if(TARGET CGAL::Ceres_support)
-    target_link_libraries(OrthoScanDeform PUBLIC CGAL::Ceres_support)
-endif()
-
-add_executable(OrthoScanBase "OrthoScanBase/OrthoScanBase.cpp" "MeshFix/MeshFix.cpp")
-target_link_libraries(OrthoScanBase PUBLIC Ortho argparse::argparse)
-
-add_executable(FakeToothRoot "FakeToothRoot/FakeToothRoot.cpp" "FakeToothRoot/FakeToothRoot.h")
-target_link_libraries(FakeToothRoot PUBLIC Ortho argparse::argparse)
-
 if(pybind11_FOUND)
-    pybind11_add_module(OrthoMeshTools "PyBind.cpp" "MeshFix/MeshFix.cpp" "SegClean/SegClean.cpp"
+    add_compile_definitions(FOUND_PYBIND11)
+    pybind11_add_module(OrthoMeshTools SHARED "PyBind.cpp" "MeshFix/MeshFix.cpp" "SegClean/SegClean.cpp"
      "ReSegment/ReSegment.cpp" "HoleMerge/HoleMerge.cpp" "GumTrimLine/GumTrimLine.cpp" "ColorMeshByLabel/ColorMeshByLabel.cpp")
-    target_link_libraries(OrthoMeshTools PUBLIC Ortho)
+    target_link_libraries(OrthoMeshTools PUBLIC Ortho pybind11::module)
     target_compile_definitions(OrthoMeshTools PUBLIC FOUND_PYBIND11)
+else ()
+    find_package(argparse)
+
+    add_executable(MeshFix "MeshFix/MeshFix.cpp" "MeshFix/MeshFix.h" "MeshFix/MeshFixApp.cpp")
+    target_compile_definitions(MeshFix PRIVATE _USE_MATH_DEFINES)
+    target_link_libraries(MeshFix PUBLIC Ortho argparse::argparse)
+
+    add_executable(SegClean "SegClean/SegClean.cpp" "SegClean/SegClean.h")
+    target_link_libraries(SegClean PUBLIC Ortho argparse::argparse)
+
+    add_executable(ReSegment "ReSegment/ReSegment.cpp" "ReSegment/ReSegment.h")
+    target_link_libraries(ReSegment PUBLIC Ortho argparse::argparse)
+
+    add_executable(HoleMerge "HoleMerge/HoleMerge.cpp" "HoleMerge/HoleMerge.h")
+    target_link_libraries(HoleMerge PUBLIC Ortho argparse::argparse)
+
+    add_executable(GumTrimLine "GumTrimLine/GumTrimLine.cpp"  "GumTrimLine/GumTrimLineApp.cpp" "GumTrimLine/GumTrimLine.h" "MeshFix/MeshFix.cpp")
+    target_link_libraries(GumTrimLine PUBLIC Ortho argparse::argparse)
+
+    add_executable(ColorMeshByLabel "ColorMeshByLabel/ColorMeshByLabel.cpp" "ColorMeshByLabel/ColorMeshByLabel.h")
+    target_link_libraries(ColorMeshByLabel PUBLIC Ortho argparse::argparse)
+
+    add_executable(OrthoScanDeform "OrthoScanDeform/OrthoScanDeformApp.cpp" "OrthoScanDeform/OrthoScanDeform.h" "MeshFix/MeshFix.cpp")
+    target_link_libraries(OrthoScanDeform PUBLIC Ortho argparse::argparse)
+    if(TARGET CGAL::Ceres_support)
+        target_link_libraries(OrthoScanDeform PUBLIC CGAL::Ceres_support)
+    endif()
+
+    add_executable(OrthoScanBase "OrthoScanBase/OrthoScanBase.cpp" "MeshFix/MeshFix.cpp")
+    target_link_libraries(OrthoScanBase PUBLIC Ortho argparse::argparse)
+
+    add_executable(FakeToothRoot "FakeToothRoot/FakeToothRoot.cpp")
+    target_link_libraries(FakeToothRoot PUBLIC Ortho argparse::argparse)
 endif()

--- a/FakeToothRoot/FakeToothRoot.cpp
+++ b/FakeToothRoot/FakeToothRoot.cpp
@@ -636,6 +636,7 @@ void Run(int argc, char* argv[])
     result_mesh.WriteOBJ(output_path);
 }
 
+#ifndef FOUND_PYBIND11
 int main(int argc, char* argv[])
 {
     std::string input_path;
@@ -715,3 +716,4 @@ int main(int argc, char* argv[])
     delete[] out_labels;
     return 0;
 }
+#endif

--- a/GumTrimLine/GumTrimLineApp.cpp
+++ b/GumTrimLine/GumTrimLineApp.cpp
@@ -1,5 +1,7 @@
 #include "GumTrimLine.h"
 #include <chrono>
+
+#ifndef FOUND_PYBIND11
 #include <argparse/argparse.hpp>
                                                                                                                                                                                                                                                        
 int main(int argc, char *argv[])
@@ -35,3 +37,4 @@ int main(int argc, char *argv[])
     }
     return 0;
 }
+#endif

--- a/MeshFix/MeshFixApp.cpp
+++ b/MeshFix/MeshFixApp.cpp
@@ -1,4 +1,6 @@
 #include "MeshFix.h"
+
+#ifndef FOUND_PYBIND11
 #include <argparse/argparse.hpp>
 
 extern bool gVerbose;
@@ -79,3 +81,4 @@ int main(int argc, char* argv[])
     }
     return 0;
 }
+#endif

--- a/OrthoScanBase/OrthoScanBase.cpp
+++ b/OrthoScanBase/OrthoScanBase.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <argparse/argparse.hpp>
 #include <CGAL/boost/graph/io.h>
 #include <CGAL/boost/graph/Face_filtered_graph.h>
 #include <CGAL/Eigen_solver_traits.h>
@@ -20,6 +19,11 @@
 #include "../MeshFix/MeshFix.h"
 #include "../EasyOBJ.h"
 #include "../SegClean/SegClean.h"
+
+#ifndef FOUND_PYBIND11
+#include <argparse/argparse.hpp>
+#endif
+
 using KernelEpick = CGAL::Exact_predicates_inexact_constructions_kernel;
 using Polyhedron = TPolyhedronWithLabel<ItemsWithLabelFlag, KernelEpick>;
 
@@ -817,6 +821,7 @@ void GenerateGum(std::string output_gum, std::string crown_frame, bool upper, Po
     std::cout << "Done." << std::endl;
 }
 
+#ifndef FOUND_PYBIND11
 int main(int argc, char *argv[])
 {
     argparse::ArgumentParser parser;
@@ -908,3 +913,4 @@ int main(int argc, char *argv[])
 
     return 0;
 }
+#endif

--- a/OrthoScanDeform/OrthoScanDeformApp.cpp
+++ b/OrthoScanDeform/OrthoScanDeformApp.cpp
@@ -1,8 +1,11 @@
 #include "OrthoScanDeform.h"
 #include <vector>
 #include <unordered_map>
-#include <argparse/argparse.hpp>
 #include <CGAL/boost/graph/io.h>
+
+#ifndef FOUND_PYBIND11
+#include <argparse/argparse.hpp>
+#endif
 
 template <typename Kernel>
 std::vector<CrownFrames<Kernel>> LoadPaths( const std::string& path )
@@ -151,6 +154,7 @@ public:
     };
 };
 
+#ifndef FOUND_PYBIND11
 int main(int argc, char* argv[])
 {
     Eigen::Matrix3f m0;
@@ -305,3 +309,4 @@ int main(int argc, char* argv[])
     }
     return 0;
 }
+#endif

--- a/PyBind.cpp
+++ b/PyBind.cpp
@@ -20,7 +20,7 @@ PYBIND11_MODULE(OrthoMeshTools, m)
         py::arg("input_labels"),
         py::arg("output_mesh"));
 
-    m.def("SegClean", &SegClean,
+    m.def("SegClean", &SegCleanF,
         "Try to make sure each label is applied to single connected component. Areas that are smaller than size_threshold are processsed.",
         py::arg("input_mesh"),
         py::arg("input_labels"),

--- a/SegClean/SegClean.cpp
+++ b/SegClean/SegClean.cpp
@@ -127,7 +127,7 @@ namespace
     }
 }
 
-bool SegClean(std::string input_mesh, std::string input_labels, std::string output_labels, int size_threshold)
+bool SegCleanF(std::string input_mesh, std::string input_labels, std::string output_labels, int size_threshold)
 {
     // Config cfg = LoadConfig(argc, argv);
     Polyhedron mesh;
@@ -203,7 +203,7 @@ bool SegClean(std::string input_mesh, std::string input_labels, std::string outp
 int main(int argc, char *argv[])
 {
     Config cfg = LoadConfig(argc, argv);
-    SegClean(cfg.input, cfg.labels, cfg.output, cfg.size_threshold);
+    SegCleanF(cfg.input, cfg.labels, cfg.output, cfg.size_threshold);
     return 0;
 }
 #endif

--- a/SegClean/SegClean.h
+++ b/SegClean/SegClean.h
@@ -4,7 +4,7 @@
 #include <queue>
 #include "../Polyhedron.h"
 
-bool SegClean(std::string input_mesh, std::string input_labels, std::string output_labels, int size_threshold);
+bool SegCleanF(std::string input_mesh, std::string input_labels, std::string output_labels, int size_threshold);
 
 template <typename Polyhedron>
 std::vector<typename Polyhedron::Vertex_handle> ConnectedComponents(typename Polyhedron::Vertex_handle hv, Polyhedron &mesh)


### PR DESCRIPTION
- Remove unnecessary `argparse` headers and dependencies while compiling python binding
- Rename `SegClean` to `SegCleanF` to fix the redefinition issue
- Move every `main()` function into the `#ifndef FOUND_PYBIND11` macro
- Modify the `CMakeLists.txt` to ensure the right and minimal dependencies for PyBind11